### PR TITLE
Fix build on Linux aarch64

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@
 
 
 
-use std::ffi::CString;
+use std::ffi::{CString, c_char};
 
 pub mod ffi;
 pub use ffi::{Rgb8, Bgr8};
@@ -181,7 +181,7 @@ impl Display {
 impl Image {
     pub unsafe fn from_raw_parts(display: &Display, data: *const u8, width: u32, height: u32) -> Self {
         let visual = XDefaultVisual(display.connection, 0);
-        let ximg = XCreateImage(display.connection, visual, 24, ZPixmap as i32, 0, data as *const i8, width, height, 32, 0);
+        let ximg = XCreateImage(display.connection, visual, 24, ZPixmap as i32, 0, data as *const c_char, width, height, 32, 0);
         // TODO: check ximg for null-ptr
         Self {
             raw: ximg
@@ -235,7 +235,7 @@ impl Image {
             let img_size = (width * height * (32 / 8)) as usize;
             let data = libc::malloc(img_size);
 
-            let ximg = XCreateImage(display.connection, visual, 24, ZPixmap as i32, 0, data as *const i8, width, height, 32, 0);
+            let ximg = XCreateImage(display.connection, visual, 24, ZPixmap as i32, 0, data as *const c_char, width, height, 32, 0);
             Self {
                 raw: ximg
             }

--- a/src/shm.rs
+++ b/src/shm.rs
@@ -139,7 +139,7 @@ impl<'a> ShmBuilder<'a> {
         unsafe {
             use libc::{shmget, shmat};
             use libc::{IPC_PRIVATE, IPC_CREAT};
-            use libc::c_void;
+            use libc::{c_char, c_void};
 
             if XShmQueryExtension(self.display.connection) {
                 let vis = XDefaultVisual(self.display.connection, 0);
@@ -155,7 +155,7 @@ impl<'a> ShmBuilder<'a> {
                     return Err(ShmError::ShmInitFailed);
                 }
 
-                let memory_addr = shmat((*shminfo).shmid, 0 as *const c_void, 0) as *mut i8;
+                let memory_addr = shmat((*shminfo).shmid, 0 as *const c_void, 0) as *mut c_char;
                 shminfo.shmaddr = memory_addr;
                 (*ximg).data = memory_addr;
                 shminfo.read_only = 0;


### PR DESCRIPTION
Linux aarch64 uses u8 instead of i8 for C `char` types.

I noticed that the codebase uses three different crates for C types (`std::ffi`, `std::os::raw` and `libc::`).
Should I also go ahead and make them all use the same?
